### PR TITLE
Update _stanford.scss

### DIFF
--- a/static/sass/_stanford.scss
+++ b/static/sass/_stanford.scss
@@ -199,7 +199,7 @@ $video-thumb-url: '../themes/stanford/images/stanford-video-thumb.png';
     clip: auto !important;
     height: 50px;
     width: 550px;
-    margin-top: 50px;
+    
 }
 
 @mixin footer_references_style {


### PR DESCRIPTION
Should remove the margin top in the login_register_h1_style mixin so that the Titles doesn't go too down
