### PR TITLE
enable Pingdom RUM

### DIFF
--- a/templates/theme-head-extra.html
+++ b/templates/theme-head-extra.html
@@ -17,3 +17,15 @@
 <!--[if IE 7]>
   <link rel="stylesheet" type="text/css" href="https://www.stanford.edu/su-identity/css/ie/ie7.css" />
 <![endif]-->
+
+<script>
+var _prum = [['id', '53b4687dabe53df34cc101fe'],
+             ['mark', 'firstbyte', (new Date()).getTime()]];
+(function() {
+    var s = document.getElementsByTagName('script')[0]
+      , p = document.createElement('script');
+    p.async = 'async';
+    p.src = '//rum-static.pingdom.net/prum.min.js';
+    s.parentNode.insertBefore(p, s);
+})();
+</script>


### PR DESCRIPTION
Pingdom has a new real-user monitoring (RUM) service.  Enable sending
perf stats (non PII) from _all_ pages to Pingdom's service, much like
we already do with Google Analytics.

I tested this locally on my machine by setting the Pingdom domain to http://class.stanford.edu:8000 and then manually setting class.stanford.edu to 127.0.0.1 in my /etc/hosts.  That seemed to work.  

@jrbl or @jbau 
